### PR TITLE
[BE]프로젝트 수정 요청에서 상태·유형 누락으로 인한 오류 방지

### DIFF
--- a/src/main/java/com/moirai/alloc/management/api/ProjectController.java
+++ b/src/main/java/com/moirai/alloc/management/api/ProjectController.java
@@ -71,7 +71,7 @@ public class ProjectController {
     @PutMapping("/{projectId}")
     public void updateProject(
             @PathVariable Long projectId,
-            @RequestBody EditProjectDTO command
+            @Valid @RequestBody EditProjectDTO command
     ) {
         if (!projectId.equals(command.getProjectId())) {
             throw new IllegalArgumentException("Project ID mismatch");

--- a/src/main/java/com/moirai/alloc/management/command/dto/EditProjectDTO.java
+++ b/src/main/java/com/moirai/alloc/management/command/dto/EditProjectDTO.java
@@ -16,9 +16,12 @@ public class EditProjectDTO {
     private LocalDate startDate;
     private LocalDate endDate;
     private Integer predictedCost;
-    private Project.ProjectType projectType;
-    private Project.ProjectStatus projectStatus;
     private String partners;
     private String description;
+
+    @NotNull
+    private Project.ProjectType projectType;
+    @NotNull
+    private Project.ProjectStatus projectStatus;
 
 }


### PR DESCRIPTION
프로젝트 수정 요청에서 상태 값이 비어 있으면 DB가 기본값을 자동으로 채워줄 거라 생각했지만,
수정(UPDATE)에서는 기본값이 적용되지 않아 null 값이 그대로 저장되면서 오류가 발생했습니다.
수정 요청에는 반드시 상태와 유형 값을 보내도록 규칙을 명확히 하여 이런 오류를 미리 막도록 변경했습니다.
즉, 수정(Edit) 요청 DTO에서 상태와 유형 필드를 필수값으로 정의하고, 컨트롤러에서 검증(@Valid)을 통해 누락된 요청을 사전에 차단했습니다.