### PR TITLE
[BE] 주간보고 생성시 주간 태스크 달성률 계산하도록 수정

### DIFF
--- a/src/main/java/com/moirai/alloc/report/command/dto/request/UpdateWeeklyReportRequest.java
+++ b/src/main/java/com/moirai/alloc/report/command/dto/request/UpdateWeeklyReportRequest.java
@@ -8,7 +8,6 @@ public record UpdateWeeklyReportRequest(
         Long reportId,
         WeeklyReport.ReportStatus reportStatus,
         String changeOfPlan,
-        Double taskCompletionRate,
         List<CompletedTaskRequest> completedTasks,
         List<IncompleteTaskRequest> incompleteTasks,
         List<NextWeekTaskRequest> nextWeekTasks

--- a/src/main/java/com/moirai/alloc/report/command/service/WeeklyReportCommandService.java
+++ b/src/main/java/com/moirai/alloc/report/command/service/WeeklyReportCommandService.java
@@ -105,7 +105,7 @@ public class WeeklyReportCommandService {
         validateMembership(report.getProjectId(), principal.userId());
         validateOwnerOrPm(report, principal);
 
-        report.updateReport(request.reportStatus(), request.changeOfPlan(), request.taskCompletionRate());
+        report.updateReport(request.reportStatus(), request.changeOfPlan(), null);
 
         issueBlockerCommandRepository.deleteByWeeklyTaskReportReportId(report.getReportId());
         weeklyTaskCommandRepository.deleteByReportReportId(report.getReportId());

--- a/src/test/java/com/moirai/alloc/report/command/controller/WeeklyReportDocsCommandControllerTest.java
+++ b/src/test/java/com/moirai/alloc/report/command/controller/WeeklyReportDocsCommandControllerTest.java
@@ -51,7 +51,6 @@ class WeeklyReportDocsCommandControllerTest {
                   "reportId": 77001,
                   "reportStatus": "REVIEWED",
                   "changeOfPlan": "변경",
-                  "taskCompletionRate": 0.8,
                   "completedTasks": [{"taskId": 77001}],
                   "incompleteTasks": [{"taskId": 77002, "delayReason": "지연"}],
                   "nextWeekTasks": [{"taskId": 77003, "plannedStartDate": "2025-01-13", "plannedEndDate": "2025-01-17"}]
@@ -93,7 +92,6 @@ class WeeklyReportDocsCommandControllerTest {
                   "reportId": 77001,
                   "reportStatus": "REVIEWED",
                   "changeOfPlan": "변경",
-                  "taskCompletionRate": 0.8,
                   "completedTasks": [{"taskId": 77001}],
                   "incompleteTasks": [{"taskId": 77002, "delayReason": "지연"}],
                   "nextWeekTasks": [{"taskId": 77003, "plannedStartDate": "2025-01-13", "plannedEndDate": "2025-01-17"}]

--- a/src/test/java/com/moirai/alloc/report/command/service/WeeklyReportCommandServiceTest.java
+++ b/src/test/java/com/moirai/alloc/report/command/service/WeeklyReportCommandServiceTest.java
@@ -77,7 +77,6 @@ class WeeklyReportCommandServiceTest {
                 REPORT_ID,
                 WeeklyReport.ReportStatus.REVIEWED,
                 "변경",
-                0.8,
                 List.of(new CompletedTaskRequest(77001L)),
                 List.of(new IncompleteTaskRequest(77002L, "지연")),
                 List.of(new NextWeekTaskRequest(


### PR DESCRIPTION
기획 단계에서는 AI로 자동 생성하려고 했으나, 계획이 변경되면서 수정할 부분이 많았던 것 같습니다.
변경 및 영향 범위를 아래와 같이 요약하였습니다.

 # Weekly Report 변경 사항 요약

  ## 1) 생성 시 taskCompletionRate 자동 계산

  - 계산 기준: 주간 보고 생성 날짜(reportDate) 기준으로 end_date <=
    reportDate인 태스크들 중 완료된 비율.
  - 저장 방식: 생성 시점에 DB weekly_report.task_completion_rate에
    저장됨.
  - 응답: WeeklyReportCreateResponse.taskCompletionRate는 저장된 값
    이 그대로 내려감.

  ## 2) 수정 시 taskCompletionRate 입력 불가

  - 요청 DTO 변경: UpdateWeeklyReportRequest에서 taskCompletionRate
    제거.
  - 수정 로직: taskCompletionRate는 더 이상 수정되지 않음(조작 방
    지).

  ## 3) 프론트 요청 변경 필요

  ### 기존

  {
    "reportId": 77001,
    "reportStatus": "REVIEWED",
    "changeOfPlan": "변경",
    "taskCompletionRate": 0.8,
    "completedTasks": [...],
    "incompleteTasks": [...],
    "nextWeekTasks": [...]
  }

  ### 변경 후

  {
    "reportId": 77001,
    "reportStatus": "REVIEWED",
    "changeOfPlan": "변경",
    "completedTasks": [...],
    "incompleteTasks": [...],
    "nextWeekTasks": [...]
  }

  ## 4) 영향 범위

  - 프론트 영향: 수정 요청에서 taskCompletionRate 필드 제거 필요.
  - 응답 스펙: WeeklyReportCreateResponse/Detail/Summary 응답의
    taskCompletionRate는 그대로 제공됨.
